### PR TITLE
Change base namespace to CrEOF\Geo\WKT to avoid class collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] 2015-11-18
+### Added
+- Change base namespace to CrEOF\Geo\WKT to avoid class collision with other CrEOF packages.
+
 ## [1.0.0] 2015-11-11
 ### Added
 - Initial release.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-0": {
-            "CrEOF\\WKT": "lib/"
+            "CrEOF\\Geo\\WKT": "lib/"
         }
     }
 }

--- a/lib/CrEOF/Geo/WKT/Exception/ExceptionInterface.php
+++ b/lib/CrEOF/Geo/WKT/Exception/ExceptionInterface.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Exception;
+namespace CrEOF\Geo\WKT\Exception;
 
 /**
- * UnexpectedValueException
+ * Exception interface for library exceptions
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+interface ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKT/Exception/InvalidArgumentException.php
+++ b/lib/CrEOF/Geo/WKT/Exception/InvalidArgumentException.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Exception;
+namespace CrEOF\Geo\WKT\Exception;
 
 /**
- * Exception interface for library exceptions
+ * InvalidArgumentException
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-interface ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKT/Exception/RangeException.php
+++ b/lib/CrEOF/Geo/WKT/Exception/RangeException.php
@@ -21,39 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
-
-use CrEOF\WKT\Parser;
+namespace CrEOF\Geo\WKT\Exception;
 
 /**
- * Basic parser tests
+ * RangeException
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class RangeException extends \RangeException implements ExceptionInterface
 {
-    /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 0: Error: Expected CrEOF\WKT\Lexer::T_TYPE, got "@" in value "@#_$%"
-     */
-    public function testParsingGarbage()
-    {
-        $value  = '@#_$%';
-        $parser = new Parser($value);
 
-        $parser->parse();
-    }
-
-    /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 0: Error: Expected CrEOF\WKT\Lexer::T_TYPE, got "PNT" in value "PNT(10 10)"
-     */
-    public function testParsingBadType()
-    {
-        $value  = 'PNT(10 10)';
-        $parser = new Parser($value);
-
-        $parser->parse();
-    }
 }

--- a/lib/CrEOF/Geo/WKT/Exception/UnexpectedValueException.php
+++ b/lib/CrEOF/Geo/WKT/Exception/UnexpectedValueException.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Exception;
+namespace CrEOF\Geo\WKT\Exception;
 
 /**
- * InvalidArgumentException
+ * UnexpectedValueException
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT;
+namespace CrEOF\Geo\WKT;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT;
+namespace CrEOF\Geo\WKT;
 
-use CrEOF\WKT\Exception\UnexpectedValueException;
+use CrEOF\Geo\WKT\Exception\UnexpectedValueException;
 
 /**
  * Parse WKT/EWKT spatial object strings

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
 
     <testsuites>
         <testsuite>
-            <directory>./tests/CrEOF/WKT/Tests</directory>
+            <directory>./tests/CrEOF/Geo/WKT/Tests</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/CrEOF/Geo/WKT/Tests/GeometryCollectionParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/GeometryCollectionParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
  * GEOMETRYCOLLECTION Parser tests
@@ -96,8 +96,8 @@ class GeometryCollectionParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 19: Error: Expected CrEOF\WKT\Lexer::T_TYPE, got "PNT" in value "GEOMETRYCOLLECTION(PNT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 19: Error: Expected CrEOF\Geo\WKT\Lexer::T_TYPE, got "PNT" in value "GEOMETRYCOLLECTION(PNT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))"
      */
     public function testParsingGeometryCollectionValueWithBadType()
     {

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Lexer;
+use CrEOF\Geo\WKT\Lexer;
 
 /**
  * Lexer tests

--- a/tests/CrEOF/Geo/WKT/Tests/LineStringParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LineStringParserTest.php
@@ -21,30 +21,28 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
- * MULTIPOINT parser tests
+ * LINESTRING parser tests
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class MultiPointParserTest extends \PHPUnit_Framework_TestCase
+class LineStringParserTest extends \PHPUnit_Framework_TestCase
 {
-    public function testParsingMultiPointValue()
+    public function testParsingLineStringValue()
     {
-        $value    = 'MULTIPOINT(0 0,10 0,10 10,0 10)';
+        $value    = 'LINESTRING(34.23 -87, 45.3 -92)';
         $parser   = new Parser($value);
         $expected = array(
             'srid'  => null,
-            'type'  => 'MULTIPOINT',
+            'type'  => 'LINESTRING',
             'value' => array(
-                array(0, 0),
-                array(10, 0),
-                array(10, 10),
-                array(0, 10)
+                array(34.23, -87),
+                array(45.3, -92)
             )
         );
 
@@ -53,18 +51,16 @@ class MultiPointParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testParsingMultiPointValueWithSrid()
+    public function testParsingLineStringValueWithSrid()
     {
-        $value    = 'SRID=4326;MULTIPOINT(0 0,10 0,10 10,0 10)';
+        $value    = 'SRID=4326;LINESTRING(34.23 -87, 45.3 -92)';
         $parser   = new Parser($value);
         $expected = array(
             'srid'  => 4326,
-            'type'  => 'MULTIPOINT',
+            'type'  => 'LINESTRING',
             'value' => array(
-                array(0, 0),
-                array(10, 0),
-                array(10, 10),
-                array(0, 10)
+                array(34.23, -87),
+                array(45.3, -92)
             )
         );
 
@@ -74,12 +70,24 @@ class MultiPointParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 11: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got "(" in value "MULTIPOINT((0 0,10 0,10 10,0 10))"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 21: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "45.3" in value "LINESTRING(34.23 -87 45.3 -92)"
      */
-    public function testParsingMultiPointValueWithExtraParenthesis()
+    public function testParsingLineStringValueMissingComma()
     {
-        $value  = 'MULTIPOINT((0 0,10 0,10 10,0 10))';
+        $value  = 'LINESTRING(34.23 -87 45.3 -92)';
+        $parser = new Parser($value);
+
+        $parser->parse();
+    }
+
+    /**
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 26: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "LINESTRING(34.23 -87, 45.3)"
+     */
+    public function testParsingLineStringValueMissingCoordinate()
+    {
+        $value  = 'LINESTRING(34.23 -87, 45.3)';
         $parser = new Parser($value);
 
         $parser->parse();

--- a/tests/CrEOF/Geo/WKT/Tests/MultiLineStringParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/MultiLineStringParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
  * MULTILINESTRING parser tests
@@ -90,8 +90,8 @@ class MultiLineStringParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 37: Error: Expected CrEOF\WKT\Lexer::T_CLOSE_PARENTHESIS, got "(" in value "MULTILINESTRING((0 0,10 0,10 10,0 10)(5 5,7 5,7 7,5 7))"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 37: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "(" in value "MULTILINESTRING((0 0,10 0,10 10,0 10)(5 5,7 5,7 7,5 7))"
      */
     public function testParsingMultiLineStringValueMissingComma()
     {

--- a/tests/CrEOF/Geo/WKT/Tests/MultiPointParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/MultiPointParserTest.php
@@ -21,28 +21,30 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
- * LINESTRING parser tests
+ * MULTIPOINT parser tests
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class LineStringParserTest extends \PHPUnit_Framework_TestCase
+class MultiPointParserTest extends \PHPUnit_Framework_TestCase
 {
-    public function testParsingLineStringValue()
+    public function testParsingMultiPointValue()
     {
-        $value    = 'LINESTRING(34.23 -87, 45.3 -92)';
+        $value    = 'MULTIPOINT(0 0,10 0,10 10,0 10)';
         $parser   = new Parser($value);
         $expected = array(
             'srid'  => null,
-            'type'  => 'LINESTRING',
+            'type'  => 'MULTIPOINT',
             'value' => array(
-                array(34.23, -87),
-                array(45.3, -92)
+                array(0, 0),
+                array(10, 0),
+                array(10, 10),
+                array(0, 10)
             )
         );
 
@@ -51,16 +53,18 @@ class LineStringParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testParsingLineStringValueWithSrid()
+    public function testParsingMultiPointValueWithSrid()
     {
-        $value    = 'SRID=4326;LINESTRING(34.23 -87, 45.3 -92)';
+        $value    = 'SRID=4326;MULTIPOINT(0 0,10 0,10 10,0 10)';
         $parser   = new Parser($value);
         $expected = array(
             'srid'  => 4326,
-            'type'  => 'LINESTRING',
+            'type'  => 'MULTIPOINT',
             'value' => array(
-                array(34.23, -87),
-                array(45.3, -92)
+                array(0, 0),
+                array(10, 0),
+                array(10, 10),
+                array(0, 10)
             )
         );
 
@@ -70,24 +74,12 @@ class LineStringParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 21: Error: Expected CrEOF\WKT\Lexer::T_CLOSE_PARENTHESIS, got "45.3" in value "LINESTRING(34.23 -87 45.3 -92)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 11: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got "(" in value "MULTIPOINT((0 0,10 0,10 10,0 10))"
      */
-    public function testParsingLineStringValueMissingComma()
+    public function testParsingMultiPointValueWithExtraParenthesis()
     {
-        $value  = 'LINESTRING(34.23 -87 45.3 -92)';
-        $parser = new Parser($value);
-
-        $parser->parse();
-    }
-
-    /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 26: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got ")" in value "LINESTRING(34.23 -87, 45.3)"
-     */
-    public function testParsingLineStringValueMissingCoordinate()
-    {
-        $value  = 'LINESTRING(34.23 -87, 45.3)';
+        $value  = 'MULTIPOINT((0 0,10 0,10 10,0 10))';
         $parser = new Parser($value);
 
         $parser->parse();

--- a/tests/CrEOF/Geo/WKT/Tests/MultiPolygonParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/MultiPolygonParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
  * MULTIPOLYGON parser tests
@@ -116,8 +116,8 @@ class MultiPolygonParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 64: Error: Expected CrEOF\WKT\Lexer::T_OPEN_PARENTHESIS, got "1" in value "MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),(1 1, 3 1, 3 3, 1 3, 1 1))"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 64: Error: Expected CrEOF\Geo\WKT\Lexer::T_OPEN_PARENTHESIS, got "1" in value "MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),(1 1, 3 1, 3 3, 1 3, 1 1))"
      */
     public function testParsingMultiPolygonValueMissingParenthesis()
     {

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -21,15 +21,39 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Exception;
+namespace CrEOF\Geo\WKT\Tests;
+
+use CrEOF\Geo\WKT\Parser;
 
 /**
- * RangeException
+ * Basic parser tests
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class RangeException extends \RangeException implements ExceptionInterface
+class ParserTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 0: Error: Expected CrEOF\Geo\WKT\Lexer::T_TYPE, got "@" in value "@#_$%"
+     */
+    public function testParsingGarbage()
+    {
+        $value  = '@#_$%';
+        $parser = new Parser($value);
 
+        $parser->parse();
+    }
+
+    /**
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 0: Error: Expected CrEOF\Geo\WKT\Lexer::T_TYPE, got "PNT" in value "PNT(10 10)"
+     */
+    public function testParsingBadType()
+    {
+        $value  = 'PNT(10 10)';
+        $parser = new Parser($value);
+
+        $parser->parse();
+    }
 }

--- a/tests/CrEOF/Geo/WKT/Tests/PointParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/PointParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
  * POINT parser tests
@@ -64,8 +64,8 @@ class PointParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 5: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got "432.6" in value "SRID=432.6;POINT(34.23 -87)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 5: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got "432.6" in value "SRID=432.6;POINT(34.23 -87)"
      */
     public function testParsingPointValueWithBadSrid()
     {
@@ -76,8 +76,8 @@ class PointParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 11: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got ")" in value "POINT(34.23)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 11: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "POINT(34.23)"
      */
     public function testParsingPointValueMissingCoordinate()
     {
@@ -88,8 +88,8 @@ class PointParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col -1: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got end of string. in value "POINT(34.23"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col -1: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got end of string. in value "POINT(34.23"
      */
     public function testParsingPointValueShortString()
     {
@@ -115,8 +115,8 @@ class PointParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 20: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got "test" in value "SRID=4326;POINT(4.23test-005 -8e-003)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 20: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got "test" in value "SRID=4326;POINT(4.23test-005 -8e-003)"
      */
     public function testParsingPointValueWrongScientificWithSrid()
     {
@@ -128,8 +128,8 @@ class PointParserTest extends \PHPUnit_Framework_TestCase
 
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\WKT\Lexer::T_INTEGER, got "," in value "POINT(10, 10)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got "," in value "POINT(10, 10)"
      */
     public function testParsingPointValueWithComma()
     {

--- a/tests/CrEOF/Geo/WKT/Tests/PolygonParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/PolygonParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKT\Tests;
+namespace CrEOF\Geo\WKT\Tests;
 
-use CrEOF\WKT\Parser;
+use CrEOF\Geo\WKT\Parser;
 
 /**
  * POLYGON parser tests
@@ -81,8 +81,8 @@ class PolygonParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\WKT\Lexer::T_OPEN_PARENTHESIS, got "0" in value "POLYGON(0 0,10 0,10 10,0 10,0 0)"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\WKT\Lexer::T_OPEN_PARENTHESIS, got "0" in value "POLYGON(0 0,10 0,10 10,0 10,0 0)"
      */
     public function testParsingPolygonValueMissingParenthesis()
     {
@@ -153,8 +153,8 @@ class PolygonParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKT\Exception\UnexpectedValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 33: Error: Expected CrEOF\WKT\Lexer::T_CLOSE_PARENTHESIS, got "(" in value "POLYGON((0 0,10 0,10 10,0 10,0 0)(5 5,7 5,7 7,5 7,5 5))"
+     * @expectedException        \CrEOF\Geo\WKT\Exception\UnexpectedValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 33: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "(" in value "POLYGON((0 0,10 0,10 10,0 10,0 0)(5 5,7 5,7 7,5 7,5 5))"
      */
     public function testParsingPolygonValueMultiRingMissingComma()
     {

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -5,5 +5,5 @@ require __DIR__ . '/../vendor/autoload.php';
 error_reporting(E_ALL | E_STRICT);
 
 $loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CrEOF\WKT\Tests', __DIR__);
+$loader->add('CrEOF\Geo\WKT\Tests', __DIR__);
 $loader->register();


### PR DESCRIPTION
Change base namespace to CrEOF\Geo\WKT to avoid class collision with other CrEOF packages.