### PR TITLE
Release 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+
 ### Changed
+
+### Removed
+
+## [2.2.0] - 2016-xx-xx
+### Added
+- Tests namespace to PSR-0 autoload in composer.json.
+- Support for 3DZ, 3DM, 4DZM objects added. Dimension(s) now in 'dimension' key of returned array.
+
+### Changed
+- Token pattern regex changed to capture numbers in scientific notation as a single value.
+- Let PHP handle scientific number conversion to float instead of manually calculating.
+- Only instantiate Lexer object in Parser constructor if it doesn't exist.
+- Move function return value tests from switch statement in Lexer. Switch statement now doing only string comparison.
+- Remove static visibility from Lexer instance in Parser.
+- PHPUnit now bootstraps Composer autoload.
+- Update PHPUnit config XML to be compliant with XSD.
+- Documentation updated for 3DZ, 3DM, 4DZM support.
+
+### Removed
+- Removed E token used with scientific notation from Lexer.
+- Removed now unused TestInit.
 
 ## [2.1.0] - 2016-04-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
-## [2.2.0] - 2016-xx-xx
+## [2.2.0] - 2016-05-03
 ### Added
 - Tests namespace to PSR-0 autoload in composer.json.
 - Support for 3DZ, 3DM, 4DZM objects added. Dimension(s) now in 'dimension' key of returned array.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test Coverage](https://codeclimate.com/github/creof/wkt-parser/badges/coverage.svg)](https://codeclimate.com/github/creof/wkt-parser/coverage)
 [![Build Status](https://travis-ci.org/creof/wkt-parser.svg?branch=master)](https://travis-ci.org/creof/wkt-parser)
 
-Lexer and parser library for WKT/EWKT spatial object strings.
+Lexer and parser library for 2D, 3D, and 4D WKT/EWKT spatial object strings.
 
 ## Usage
 
@@ -33,10 +33,11 @@ $value2 = $parser->parse($input2);
 
 ## Return
 
-The parser will return an array with the keys ```srid```, ```type```, and ```value```.
-- ```type``` is the spatial object type (POINT, LINESTRING, etc.)
-- ```value``` will contain an array with integer or float values for points, or nested arrays containing these based on spatial object type.
-- ```srid``` is the SRID if EWKT value was parsed, null otherwise.
+The parser will return an array with the keys ```type```, ```value```, ```srid```, and ```dimension```.
+- ```type``` string, the spatial object type (POINT, LINESTRING, etc.) without any dimension.
+- ```value``` array, contains integer or float values for points, or nested arrays containing these based on spatial object type.
+- ```srid``` integer, the SRID if EWKT value was parsed, ```null``` otherwise.
+- ```dimension``` string, will contain ```Z```, ```M```, or ```ZM``` for the respective 3D and 4D objects, ```null``` otherwise.
 
 ## Exceptions
 

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ The parser will return an array with the keys ```srid```, ```type```, and ```val
 
 ## Exceptions
 
-The ```Lexer``` and ```Parser``` will throw expections implementing interface ```CrEOF\Geo\WKT\Exception\ExceptionInterface```.
+The ```Lexer``` and ```Parser``` will throw exceptions implementing interface ```CrEOF\Geo\WKT\Exception\ExceptionInterface```.

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "doctrine/lexer": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit":               "<5.0",
+        "phpunit/phpunit":               ">=4.8",
         "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
         "psr-0": {
             "CrEOF\\Geo\\WKT": "lib/"
         }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "CrEOF\\Geo\\WKT\\Tests": "tests/"
+        }
     }
 }

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -94,32 +94,36 @@ class Lexer extends AbstractLexer
      */
     protected function getType(&$value)
     {
-        switch (true) {
-            case (is_numeric($value)):
-                $value += 0;
+        if (is_numeric($value)) {
+            $value += 0;
 
-                if (is_int($value)) {
-                    return self::T_INTEGER;
-                }
+            if (is_int($value)) {
+                return self::T_INTEGER;
+            }
 
-                return self::T_FLOAT;
-            case (ctype_alpha($value)):
-                $name = __CLASS__ . '::T_' . strtoupper($value);
+            return self::T_FLOAT;
+        }
 
-                if (defined($name)) {
-                    return constant($name);
-                }
+        if (ctype_alpha($value)) {
+            $name = __CLASS__ . '::T_' . strtoupper($value);
 
-                return self::T_STRING;
-            case ($value === ','):
+            if (defined($name)) {
+                return constant($name);
+            }
+
+            return self::T_STRING;
+        }
+
+        switch ($value) {
+            case ',':
                 return self::T_COMMA;
-            case ($value === '('):
+            case '(':
                 return self::T_OPEN_PARENTHESIS;
-            case ($value === ')'):
+            case ')':
                 return self::T_CLOSE_PARENTHESIS;
-            case ($value === '='):
+            case '=':
                 return self::T_EQUALS;
-            case ($value === ';'):
+            case ';':
                 return self::T_SEMICOLON;
             default:
                 return self::T_NONE;

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -36,7 +36,6 @@ class Lexer extends AbstractLexer
     const T_NONE               = 1;
     const T_INTEGER            = 2;
     const T_STRING             = 3;
-    const T_E                  = 4;
     const T_FLOAT              = 5;
     const T_CLOSE_PARENTHESIS  = 6;
     const T_OPEN_PARENTHESIS   = 7;
@@ -97,17 +96,13 @@ class Lexer extends AbstractLexer
     {
         switch (true) {
             case (is_numeric($value)):
-                if (strpos($value, '.') !== false) {
-                    $value = (float) $value;
+                $value += 0;
 
-                    return self::T_FLOAT;
+                if (is_int($value)) {
+                    return self::T_INTEGER;
                 }
 
-                $value = (int) $value;
-
-                return self::T_INTEGER;
-            case (strtoupper($value) === 'E'):
-                return self::T_E;
+                return self::T_FLOAT;
             case (ctype_alpha($value)):
                 $name = __CLASS__ . '::T_' . strtoupper($value);
 
@@ -139,7 +134,7 @@ class Lexer extends AbstractLexer
         return array(
             '',
             'zm|[a-z]+[a-ln-z]',
-            '[+-]?[0-9]+(?:[\.][0-9]+)?'
+            '[+-]?[0-9]+(?:[\.][0-9]+)?(?:e[+-]?[0-9]+)?'
         );
     }
 

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -137,7 +137,7 @@ class Lexer extends AbstractLexer
     {
         return array(
             '',
-            'zm|[a-z]+[a-ln-z]',
+            'zm|[a-z]+[a-ln-y]',
             '[+-]?[0-9]+(?:[\.][0-9]+)?(?:e[+-]?[0-9]+)?'
         );
     }

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -54,7 +54,7 @@ class Parser
     private static $lexer;
 
     /**
-     * @param string $input
+     * @param string|null $input
      */
     public function __construct($input = null)
     {
@@ -68,6 +68,8 @@ class Parser
     }
 
     /**
+     * @param string|null $input
+     *
      * @return array
      */
     public function parse($input = null)

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -164,7 +164,7 @@ class Parser
     protected function point()
     {
         if (null !== $this->dimension) {
-            return $this->coordinates(2 + count($this->dimension));
+            return $this->coordinates(2 + strlen($this->dimension));
         }
 
         $values = $this->coordinates(2);

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -51,16 +51,14 @@ class Parser
     /**
      * @var Lexer
      */
-    private static $lexer;
+    private $lexer;
 
     /**
      * @param string|null $input
      */
     public function __construct($input = null)
     {
-        if (null === self::$lexer) {
-            self::$lexer = new Lexer();
-        }
+        $this->lexer = new Lexer();
 
         if (null !== $input) {
             $this->input = $input;
@@ -78,12 +76,12 @@ class Parser
             $this->input = $input;
         }
 
-        self::$lexer->setInput($this->input);
-        self::$lexer->moveNext();
+        $this->lexer->setInput($this->input);
+        $this->lexer->moveNext();
 
         $this->srid = null;
 
-        if (self::$lexer->isNextToken(Lexer::T_SRID)) {
+        if ($this->lexer->isNextToken(Lexer::T_SRID)) {
             $this->srid = $this->srid();
         }
 
@@ -104,7 +102,7 @@ class Parser
         $this->match(Lexer::T_EQUALS);
         $this->match(Lexer::T_INTEGER);
 
-        $srid = self::$lexer->value();
+        $srid = $this->lexer->value();
 
         $this->match(Lexer::T_SEMICOLON);
 
@@ -120,7 +118,7 @@ class Parser
     {
         $this->match(Lexer::T_TYPE);
 
-        return self::$lexer->value();
+        return $this->lexer->value();
     }
 
     /**
@@ -133,8 +131,8 @@ class Parser
         $type       = $this->type();
         $this->type = $type;
 
-        if (self::$lexer->isNextTokenAny(array(Lexer::T_Z, Lexer::T_M, Lexer::T_ZM))) {
-            $this->match(self::$lexer->lookahead['type']);
+        if ($this->lexer->isNextTokenAny(array(Lexer::T_Z, Lexer::T_M, Lexer::T_ZM))) {
+            $this->match($this->lexer->lookahead['type']);
         }
 
         $this->match(Lexer::T_OPEN_PARENTHESIS);
@@ -169,9 +167,9 @@ class Parser
      */
     protected function coordinate()
     {
-        $this->match((self::$lexer->isNextToken(Lexer::T_FLOAT) ? Lexer::T_FLOAT : Lexer::T_INTEGER));
+        $this->match(($this->lexer->isNextToken(Lexer::T_FLOAT) ? Lexer::T_FLOAT : Lexer::T_INTEGER));
 
-        return self::$lexer->value();
+        return $this->lexer->value();
     }
 
     /**
@@ -203,7 +201,7 @@ class Parser
     {
         $points = array($this->point());
 
-        while (self::$lexer->isNextToken(Lexer::T_COMMA)) {
+        while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
 
             $points[] = $this->point();
@@ -225,7 +223,7 @@ class Parser
 
         $this->match(Lexer::T_CLOSE_PARENTHESIS);
 
-        while (self::$lexer->isNextToken(Lexer::T_COMMA)) {
+        while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
             $this->match(Lexer::T_OPEN_PARENTHESIS);
 
@@ -250,7 +248,7 @@ class Parser
 
         $this->match(Lexer::T_CLOSE_PARENTHESIS);
 
-        while (self::$lexer->isNextToken(Lexer::T_COMMA)) {
+        while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
             $this->match(Lexer::T_OPEN_PARENTHESIS);
 
@@ -291,7 +289,7 @@ class Parser
     {
         $collection = array($this->geometry());
 
-        while (self::$lexer->isNextToken(Lexer::T_COMMA)) {
+        while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
 
             $collection[] = $this->geometry();
@@ -307,13 +305,13 @@ class Parser
      */
     protected function match($token)
     {
-        $lookaheadType = self::$lexer->lookahead['type'];
+        $lookaheadType = $this->lexer->lookahead['type'];
 
         if ($lookaheadType !== $token && ($token !== Lexer::T_TYPE || $lookaheadType <= Lexer::T_TYPE)) {
-            throw $this->syntaxError(self::$lexer->getLiteral($token));
+            throw $this->syntaxError($this->lexer->getLiteral($token));
         }
 
-        self::$lexer->moveNext();
+        $this->lexer->moveNext();
     }
 
     /**
@@ -326,8 +324,8 @@ class Parser
     private function syntaxError($expected)
     {
         $expected = sprintf('Expected %s, got', $expected);
-        $token    = self::$lexer->lookahead;
-        $found    = null === self::$lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
+        $token    = $this->lexer->lookahead;
+        $found    = null === $this->lexer->lookahead ? 'end of string.' : sprintf('"%s"', $token['value']);
         $message  = sprintf(
             '[Syntax Error] line 0, col %d: Error: %s %s in value "%s"',
             isset($token['position']) ? $token['position'] : '-1',

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -171,16 +171,7 @@ class Parser
     {
         $this->match((self::$lexer->isNextToken(Lexer::T_FLOAT) ? Lexer::T_FLOAT : Lexer::T_INTEGER));
 
-        if (! self::$lexer->isNextToken(Lexer::T_E)) {
-            return self::$lexer->value();
-        }
-
-        $number = self::$lexer->value();
-
-        $this->match(Lexer::T_E);
-        $this->match(Lexer::T_INTEGER);
-
-        return $number * pow(10, self::$lexer->value());
+        return self::$lexer->value();
     }
 
     /**

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -93,7 +93,7 @@ class Parser
 
         $geometry              = $this->geometry();
         $geometry['srid']      = $this->srid;
-        $geometry['dimension'] = $this->dimension;
+        $geometry['dimension'] = '' === $this->dimension ? null : $this->dimension;
 
         return $geometry;
     }
@@ -174,6 +174,9 @@ class Parser
         }
 
         switch (count($values)) {
+            case 2:
+                $this->dimension = '';
+                break;
             case 3:
                 $this->dimension = 'Z';
                 break;

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -58,7 +58,9 @@ class Parser
      */
     public function __construct($input = null)
     {
-        self::$lexer = new Lexer();
+        if (null === self::$lexer) {
+            self::$lexer = new Lexer();
+        }
 
         if (null !== $input) {
             $this->input = $input;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit backupGlobals="false"
-         colors="true"
-         bootstrap="./tests/TestInit.php"
-        >
+        backupGlobals="false"
+        colors="true"
+        bootstrap="./vendor/autoload.php"
+>
 
     <testsuites>
         <testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
         backupGlobals="false"
         colors="true"
         bootstrap="./vendor/autoload.php"
 >
 
     <testsuites>
-        <testsuite>
+        <testsuite name="Tests">
             <directory>./tests/CrEOF/Geo/WKT/Tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">lib</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -227,9 +227,7 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                     array(Lexer::T_FLOAT, 20.5, 42),
                     array(Lexer::T_FLOAT, 25.9, 47),
                     array(Lexer::T_COMMA, ',', 51),
-                    array(Lexer::T_INTEGER, 53, 53),
-                    array(Lexer::T_E, 'E', 55),
-                    array(Lexer::T_INTEGER, -3, 56),
+                    array(Lexer::T_FLOAT, 0.053, 53),
                     array(Lexer::T_INTEGER, 60, 61),
                     array(Lexer::T_CLOSE_PARENTHESIS, ')', 63)
                 )

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -33,208 +33,6 @@ use CrEOF\Geo\WKT\Lexer;
  */
 class LexerTest extends \PHPUnit_Framework_TestCase
 {
-
-    /**
-     * @return array
-     */
-    public function tokenData()
-    {
-        return array(
-            'POINT' => array(
-                'value' => 'POINT',
-                'expected' => array(
-                    array(Lexer::T_POINT, 'POINT', 0)
-                )
-            ),
-            'POINTM' => array(
-                'value' => 'POINTM',
-                'expected' => array(
-                    array(Lexer::T_POINT, 'POINT', 0),
-                    array(Lexer::T_M, 'M', 5)
-                )
-            ),
-            'POINT M' => array(
-                'value' => 'POINTM',
-                'expected' => array(
-                    array(Lexer::T_POINT, 'POINT', 0),
-                    array(Lexer::T_M, 'M', 5)
-                )
-            ),
-            'POINT Z' => array(
-                'value' => 'POINT Z',
-                'expected' => array(
-                    array(Lexer::T_POINT, 'POINT', 0),
-                    array(Lexer::T_Z, 'Z', 6)
-                )
-            ),
-            'POINT ZM' => array(
-                'value' => 'POINT ZM',
-                'expected' => array(
-                    array(Lexer::T_POINT, 'POINT', 0),
-                    array(Lexer::T_ZM, 'ZM', 6)
-                )
-            ),
-            'POINTZM' => array(
-                'value' => 'POINTZM',
-                'expected' => array(
-                    array(Lexer::T_STRING, 'POINTZ', 0),
-                    array(Lexer::T_M, 'M', 6)
-                )
-            ),
-            'LINESTRING' => array(
-                'value' => 'LINESTRING',
-                'expected' => array(
-                    array(Lexer::T_LINESTRING, 'LINESTRING', 0)
-                )
-            ),
-            'LINESTRINGM' => array(
-                'value' => 'LINESTRINGM',
-                'expected' => array(
-                    array(Lexer::T_LINESTRING, 'LINESTRING', 0),
-                    array(Lexer::T_M, 'M', 10)
-                )
-            ),
-            'POLYGON' => array(
-                'value' => 'POLYGON',
-                'expected' => array(
-                    array(Lexer::T_POLYGON, 'POLYGON', 0)
-                )
-            ),
-            'POLYGONM' => array(
-                'value' => 'POLYGONM',
-                'expected' => array(
-                    array(Lexer::T_POLYGON, 'POLYGON', 0),
-                    array(Lexer::T_M, 'M', 7)
-                )
-            ),
-            'MULTIPOINT' => array(
-                'value' => 'MULTIPOINT',
-                'expected' => array(
-                    array(Lexer::T_MULTIPOINT, 'MULTIPOINT', 0)
-                )
-            ),
-            'MULTIPOINTM' => array(
-                'value' => 'MULTIPOINTM',
-                'expected' => array(
-                    array(Lexer::T_MULTIPOINT, 'MULTIPOINT', 0),
-                    array(Lexer::T_M, 'M', 10)
-                )
-            ),
-            'MULTILINESTRING' => array(
-                'value' => 'MULTILINESTRING',
-                'expected' => array(
-                    array(Lexer::T_MULTILINESTRING, 'MULTILINESTRING', 0)
-                )
-            ),
-            'MULTILINESTRINGM' => array(
-                'value' => 'MULTILINESTRINGM',
-                'expected' => array(
-                    array(Lexer::T_MULTILINESTRING, 'MULTILINESTRING', 0),
-                    array(Lexer::T_M, 'M', 15)
-                )
-            ),
-            'MULTIPOLYGON' => array(
-                'value' => 'MULTIPOLYGON',
-                'expected' => array(
-                    array(Lexer::T_MULTIPOLYGON, 'MULTIPOLYGON', 0)
-                )
-            ),
-            'MULTIPOLYGONM' => array(
-                'value' => 'MULTIPOLYGONM',
-                'expected' => array(
-                    array(Lexer::T_MULTIPOLYGON, 'MULTIPOLYGON', 0),
-                    array(Lexer::T_M, 'M', 12)
-                )
-            ),
-            'GEOMETRYCOLLECTION' => array(
-                'value' => 'GEOMETRYCOLLECTION',
-                'expected' => array(
-                    array(Lexer::T_GEOMETRYCOLLECTION, 'GEOMETRYCOLLECTION', 0)
-                )
-            ),
-            'GEOMETRYCOLLECTIONM' => array(
-                'value' => 'GEOMETRYCOLLECTIONM',
-                'expected' => array(
-                    array(Lexer::T_GEOMETRYCOLLECTION, 'GEOMETRYCOLLECTION', 0),
-                    array(Lexer::T_M, 'M', 18)
-                )
-            ),
-            'COMPOUNDCURVE' => array(
-                'value' => 'COMPOUNDCURVE',
-                'expected' => array(
-                    array(Lexer::T_COMPOUNDCURVE, 'COMPOUNDCURVE', 0)
-                )
-            ),
-            'COMPOUNDCURVEM' => array(
-                'value' => 'COMPOUNDCURVEM',
-                'expected' => array(
-                    array(Lexer::T_COMPOUNDCURVE, 'COMPOUNDCURVE', 0),
-                    array(Lexer::T_M, 'M', 13)
-                )
-            ),
-            'CIRCULARSTRING' => array(
-                'value' => 'CIRCULARSTRING',
-                'expected' => array(
-                    array(Lexer::T_CIRCULARSTRING, 'CIRCULARSTRING', 0)
-                )
-            ),
-            'CIRCULARSTRINGM' => array(
-                'value' => 'CIRCULARSTRINGM',
-                'expected' => array(
-                    array(Lexer::T_CIRCULARSTRING, 'CIRCULARSTRING', 0),
-                    array(Lexer::T_M, 'M', 14)
-                )
-            ),
-            '35' => array(
-                'value' => '35',
-                'expected' => array(
-                    array(Lexer::T_INTEGER, 35, 0)
-                )
-            ),
-            '-25' => array(
-                'value' => '-25',
-                'expected' => array(
-                    array(Lexer::T_INTEGER, -25, 0)
-                )
-            ),
-            '-120.33' => array(
-                'value' => '-120.33',
-                'expected' => array(
-                    array(Lexer::T_FLOAT, -120.33, 0)
-                )
-            ),
-            'SRID' => array(
-                'value' => 'SRID',
-                'expected' => array(
-                    array(Lexer::T_SRID, 'SRID', 0)
-                )
-            ),
-            'SRID=4326;LINESTRING(0 0.0, 10.1 -10.025, 20.5 25.9, 53E-003 60)' => array(
-                'value' => 'SRID=4326;LINESTRING(0 0.0, 10.1 -10.025, 20.5 25.9, 53E-003 60)',
-                'expected' => array(
-                    array(Lexer::T_SRID, 'SRID', 0),
-                    array(Lexer::T_EQUALS, '=', 4),
-                    array(Lexer::T_INTEGER, 4326, 5),
-                    array(Lexer::T_SEMICOLON, ';', 9),
-                    array(Lexer::T_LINESTRING, 'LINESTRING', 10),
-                    array(Lexer::T_OPEN_PARENTHESIS, '(', 20),
-                    array(Lexer::T_INTEGER, 0, 21),
-                    array(Lexer::T_FLOAT, 0, 23),
-                    array(Lexer::T_COMMA, ',', 26),
-                    array(Lexer::T_FLOAT, 10.1, 28),
-                    array(Lexer::T_FLOAT, -10.025, 33),
-                    array(Lexer::T_COMMA, ',', 40),
-                    array(Lexer::T_FLOAT, 20.5, 42),
-                    array(Lexer::T_FLOAT, 25.9, 47),
-                    array(Lexer::T_COMMA, ',', 51),
-                    array(Lexer::T_FLOAT, 0.053, 53),
-                    array(Lexer::T_INTEGER, 60, 61),
-                    array(Lexer::T_CLOSE_PARENTHESIS, ')', 63)
-                )
-            )
-        );
-    }
-
     /**
      * @param       $value
      * @param array $expected
@@ -273,5 +71,206 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals($token[2], $actual['position']);
             }
         }
+    }
+
+    /**
+     * @return array
+     */
+    public function tokenData()
+    {
+        return array(
+            'POINT' => array(
+                'value'    => 'POINT',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0)
+                )
+            ),
+            'POINTM' => array(
+                'value'    => 'POINTM',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_M, 'M', 5)
+                )
+            ),
+            'POINT M' => array(
+                'value'    => 'POINTM',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_M, 'M', 5)
+                )
+            ),
+            'POINT Z' => array(
+                'value'    => 'POINT Z',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_Z, 'Z', 6)
+                )
+            ),
+            'POINT ZM' => array(
+                'value'    => 'POINT ZM',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_ZM, 'ZM', 6)
+                )
+            ),
+            'POINTZM' => array(
+                'value'    => 'POINTZM',
+                'expected' => array(
+                    array(Lexer::T_STRING, 'POINTZ', 0),
+                    array(Lexer::T_M, 'M', 6)
+                )
+            ),
+            'LINESTRING' => array(
+                'value'    => 'LINESTRING',
+                'expected' => array(
+                    array(Lexer::T_LINESTRING, 'LINESTRING', 0)
+                )
+            ),
+            'LINESTRINGM' => array(
+                'value'    => 'LINESTRINGM',
+                'expected' => array(
+                    array(Lexer::T_LINESTRING, 'LINESTRING', 0),
+                    array(Lexer::T_M, 'M', 10)
+                )
+            ),
+            'POLYGON' => array(
+                'value'    => 'POLYGON',
+                'expected' => array(
+                    array(Lexer::T_POLYGON, 'POLYGON', 0)
+                )
+            ),
+            'POLYGONM' => array(
+                'value'    => 'POLYGONM',
+                'expected' => array(
+                    array(Lexer::T_POLYGON, 'POLYGON', 0),
+                    array(Lexer::T_M, 'M', 7)
+                )
+            ),
+            'MULTIPOINT' => array(
+                'value'    => 'MULTIPOINT',
+                'expected' => array(
+                    array(Lexer::T_MULTIPOINT, 'MULTIPOINT', 0)
+                )
+            ),
+            'MULTIPOINTM' => array(
+                'value'    => 'MULTIPOINTM',
+                'expected' => array(
+                    array(Lexer::T_MULTIPOINT, 'MULTIPOINT', 0),
+                    array(Lexer::T_M, 'M', 10)
+                )
+            ),
+            'MULTILINESTRING' => array(
+                'value'    => 'MULTILINESTRING',
+                'expected' => array(
+                    array(Lexer::T_MULTILINESTRING, 'MULTILINESTRING', 0)
+                )
+            ),
+            'MULTILINESTRINGM' => array(
+                'value'    => 'MULTILINESTRINGM',
+                'expected' => array(
+                    array(Lexer::T_MULTILINESTRING, 'MULTILINESTRING', 0),
+                    array(Lexer::T_M, 'M', 15)
+                )
+            ),
+            'MULTIPOLYGON' => array(
+                'value'    => 'MULTIPOLYGON',
+                'expected' => array(
+                    array(Lexer::T_MULTIPOLYGON, 'MULTIPOLYGON', 0)
+                )
+            ),
+            'MULTIPOLYGONM' => array(
+                'value'    => 'MULTIPOLYGONM',
+                'expected' => array(
+                    array(Lexer::T_MULTIPOLYGON, 'MULTIPOLYGON', 0),
+                    array(Lexer::T_M, 'M', 12)
+                )
+            ),
+            'GEOMETRYCOLLECTION' => array(
+                'value'    => 'GEOMETRYCOLLECTION',
+                'expected' => array(
+                    array(Lexer::T_GEOMETRYCOLLECTION, 'GEOMETRYCOLLECTION', 0)
+                )
+            ),
+            'GEOMETRYCOLLECTIONM' => array(
+                'value'    => 'GEOMETRYCOLLECTIONM',
+                'expected' => array(
+                    array(Lexer::T_GEOMETRYCOLLECTION, 'GEOMETRYCOLLECTION', 0),
+                    array(Lexer::T_M, 'M', 18)
+                )
+            ),
+            'COMPOUNDCURVE' => array(
+                'value'    => 'COMPOUNDCURVE',
+                'expected' => array(
+                    array(Lexer::T_COMPOUNDCURVE, 'COMPOUNDCURVE', 0)
+                )
+            ),
+            'COMPOUNDCURVEM' => array(
+                'value'    => 'COMPOUNDCURVEM',
+                'expected' => array(
+                    array(Lexer::T_COMPOUNDCURVE, 'COMPOUNDCURVE', 0),
+                    array(Lexer::T_M, 'M', 13)
+                )
+            ),
+            'CIRCULARSTRING' => array(
+                'value'    => 'CIRCULARSTRING',
+                'expected' => array(
+                    array(Lexer::T_CIRCULARSTRING, 'CIRCULARSTRING', 0)
+                )
+            ),
+            'CIRCULARSTRINGM' => array(
+                'value'    => 'CIRCULARSTRINGM',
+                'expected' => array(
+                    array(Lexer::T_CIRCULARSTRING, 'CIRCULARSTRING', 0),
+                    array(Lexer::T_M, 'M', 14)
+                )
+            ),
+            '35' => array(
+                'value'    => '35',
+                'expected' => array(
+                    array(Lexer::T_INTEGER, 35, 0)
+                )
+            ),
+            '-25' => array(
+                'value'    => '-25',
+                'expected' => array(
+                    array(Lexer::T_INTEGER, -25, 0)
+                )
+            ),
+            '-120.33' => array(
+                'value'    => '-120.33',
+                'expected' => array(
+                    array(Lexer::T_FLOAT, -120.33, 0)
+                )
+            ),
+            'SRID' => array(
+                'value'    => 'SRID',
+                'expected' => array(
+                    array(Lexer::T_SRID, 'SRID', 0)
+                )
+            ),
+            'SRID=4326;LINESTRING(0 0.0, 10.1 -10.025, 20.5 25.9, 53E-003 60)' => array(
+                'value'    => 'SRID=4326;LINESTRING(0 0.0, 10.1 -10.025, 20.5 25.9, 53E-003 60)',
+                'expected' => array(
+                    array(Lexer::T_SRID, 'SRID', 0),
+                    array(Lexer::T_EQUALS, '=', 4),
+                    array(Lexer::T_INTEGER, 4326, 5),
+                    array(Lexer::T_SEMICOLON, ';', 9),
+                    array(Lexer::T_LINESTRING, 'LINESTRING', 10),
+                    array(Lexer::T_OPEN_PARENTHESIS, '(', 20),
+                    array(Lexer::T_INTEGER, 0, 21),
+                    array(Lexer::T_FLOAT, 0, 23),
+                    array(Lexer::T_COMMA, ',', 26),
+                    array(Lexer::T_FLOAT, 10.1, 28),
+                    array(Lexer::T_FLOAT, -10.025, 33),
+                    array(Lexer::T_COMMA, ',', 40),
+                    array(Lexer::T_FLOAT, 20.5, 42),
+                    array(Lexer::T_FLOAT, 25.9, 47),
+                    array(Lexer::T_COMMA, ',', 51),
+                    array(Lexer::T_FLOAT, 0.053, 53),
+                    array(Lexer::T_INTEGER, 60, 61),
+                    array(Lexer::T_CLOSE_PARENTHESIS, ')', 63)
+                )
+            )
+        );
     }
 }

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -99,6 +99,13 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                     array(Lexer::T_M, 'M', 5)
                 )
             ),
+            'POINTZ' => array(
+                'value'    => 'POINTZ',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_Z, 'Z', 5)
+                )
+            ),
             'POINT Z' => array(
                 'value'    => 'POINT Z',
                 'expected' => array(

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -123,8 +123,8 @@ class LexerTest extends \PHPUnit_Framework_TestCase
             'POINTZM' => array(
                 'value'    => 'POINTZM',
                 'expected' => array(
-                    array(Lexer::T_STRING, 'POINTZ', 0),
-                    array(Lexer::T_M, 'M', 6)
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_ZM, 'ZM', 5)
                 )
             ),
             'LINESTRING' => array(

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2015 Derek J. Lambert
+ * Copyright (C) 2016 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -23,6 +23,7 @@
 
 namespace CrEOF\Geo\WKT\Tests;
 
+use CrEOF\Geo\WKT\Exception\ExceptionInterface;
 use CrEOF\Geo\WKT\Exception\UnexpectedValueException;
 use CrEOF\Geo\WKT\Parser;
 
@@ -44,11 +45,11 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     {
         $parser = new Parser($value);
 
-        try {
-            $actual = $parser->parse();
-        } catch (\Exception $e) {
-            $actual = $e;
+        if ($expected instanceof ExceptionInterface) {
+            $this->setExpectedException(get_class($expected), $expected->getMessage());
         }
+
+        $actual = $parser->parse();
 
         $this->assertEquals($expected, $actual);
     }
@@ -58,13 +59,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $parser = new Parser();
 
         foreach ($this->parserTestData() as $name => $testData) {
-            try {
-                $actual = $parser->parse($testData['value']);
-            } catch (\Exception $e) {
-                $actual = $e;
+            $value    = $testData['value'];
+            $expected = $testData['expected'];
+
+            if ($expected instanceof ExceptionInterface) {
+                $this->setExpectedException(get_class($expected), $expected->getMessage());
             }
 
-            $this->assertEquals($testData['expected'], $actual, 'Failed dataset "'. $name . '"');
+            $actual = $parser->parse($value);
+
+            $this->assertEquals($expected, $actual, 'Failed dataset "'. $name . '"');
         }
     }
 

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -89,25 +89,73 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingPointValue' => array(
                 'value'    => 'POINT(34.23 -87)',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'POINT',
-                    'value' => array(34.23, -87)
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87),
+                    'dimension' => null
+                )
+            ),
+            'testParsingPointZValue' => array(
+                'value'    => 'POINT(34.23 -87 10)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10),
+                    'dimension' => 'Z'
+                )
+            ),
+            'testParsingPointDeclaredZValue' => array(
+                'value'    => 'POINTZ(34.23 -87 10)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10),
+                    'dimension' => 'Z'
+                )
+            ),
+            'testParsingPointMValue' => array(
+                'value'    => 'POINTM(34.23 -87 10)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10),
+                    'dimension' => 'M'
+                )
+            ),
+            'testParsingPointZMValue' => array(
+                'value'    => 'POINT(34.23 -87 10 30)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10, 30),
+                    'dimension' => 'ZM'
+                )
+            ),
+            'testParsingPointDeclaredZMValue' => array(
+                'value'    => 'POINT ZM(34.23 -87 10 30)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10, 30),
+                    'dimension' => 'ZM'
                 )
             ),
             'testParsingPointValueWithSrid' => array(
                 'value'    => 'SRID=4326;POINT(34.23 -87)',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'POINT',
-                    'value' => array(34.23, -87)
+                    'srid'      => 4326,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87),
+                    'dimension' => null
                 )
             ),
             'testParsingPointValueScientificWithSrid' => array(
                 'value'    => 'SRID=4326;POINT(4.23e-005 -8E-003)',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'POINT',
-                    'value' => array(0.0000423, -0.008)
+                    'srid'      => 4326,
+                    'type'      => 'POINT',
+                    'value'     => array(0.0000423, -0.008),
+                    'dimension' => null
                 )
             ),
             'testParsingPointValueWithBadSrid' => array(
@@ -133,28 +181,26 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingLineStringValue' => array(
                 'value'    => 'LINESTRING(34.23 -87, 45.3 -92)',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'LINESTRING',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(
                         array(34.23, -87),
                         array(45.3, -92)
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingLineStringValueWithSrid' => array(
                 'value'    => 'SRID=4326;LINESTRING(34.23 -87, 45.3 -92)',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'LINESTRING',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(
                         array(34.23, -87),
                         array(45.3, -92)
-                    )
+                    ),
+                    'dimension' => null
                 )
-            ),
-            'testParsingLineStringValueMissingComma' => array(
-                'value'    => 'LINESTRING(34.23 -87 45.3 -92)',
-                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 21: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "45.3" in value "LINESTRING(34.23 -87 45.3 -92)"')
             ),
             'testParsingLineStringValueMissingCoordinate' => array(
                 'value'    => 'LINESTRING(34.23 -87, 45.3)',
@@ -163,9 +209,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingPolygonValue' => array(
                 'value'    => 'POLYGON((0 0,10 0,10 10,0 10,0 0))',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'POLYGON',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -173,15 +219,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10),
                             array(0, 0)
                         )
-                    )
+                    ) ,
+                    'dimension' => null
                 )
             ),
             'testParsingPolygonValueWithSrid' => array(
                 'value'    => 'SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0))',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'POLYGON',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -189,15 +236,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10),
                             array(0, 0)
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingPolygonValueMultiRing' => array(
                 'value'    => 'POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5))',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'POLYGON',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -212,15 +260,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(5, 7),
                             array(5, 5)
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingPolygonValueMultiRingWithSrid' => array(
                 'value'    => 'SRID=4326;POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5))',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'POLYGON',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -235,7 +284,8 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(5, 7),
                             array(5, 5)
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingPolygonValueMissingParenthesis' => array(
@@ -249,27 +299,29 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingMultiPointValue' => array(
                 'value'    => 'MULTIPOINT(0 0,10 0,10 10,0 10)',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'MULTIPOINT',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'MULTIPOINT',
+                    'value'     => array(
                         array(0, 0),
                         array(10, 0),
                         array(10, 10),
                         array(0, 10)
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiPointValueWithSrid' => array(
                 'value'    => 'SRID=4326;MULTIPOINT(0 0,10 0,10 10,0 10)',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'MULTIPOINT',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'MULTIPOINT',
+                    'value'     => array(
                         array(0, 0),
                         array(10, 0),
                         array(10, 10),
                         array(0, 10)
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiPointValueWithExtraParenthesis' => array(
@@ -279,9 +331,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingMultiLineStringValue' => array(
                 'value'    => 'MULTILINESTRING((0 0,10 0,10 10,0 10),(5 5,7 5,7 7,5 7))',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'MULTILINESTRING',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'MULTILINESTRING',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -294,15 +346,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(7, 7),
                             array(5, 7),
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiLineStringValueWithSrid' => array(
                 'value'    => 'SRID=4326;MULTILINESTRING((0 0,10 0,10 10,0 10),(5 5,7 5,7 7,5 7))',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'MULTILINESTRING',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'MULTILINESTRING',
+                    'value'     => array(
                         array(
                             array(0, 0),
                             array(10, 0),
@@ -315,7 +368,8 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(7, 7),
                             array(5, 7),
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiLineStringValueMissingComma' => array(
@@ -325,9 +379,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingMultiPolygonValue' => array(
                 'value'    => 'MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),((1 1, 3 1, 3 3, 1 3, 1 1)))',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'MULTIPOLYGON',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'MULTIPOLYGON',
+                    'value'     => array(
                         array(
                             array(
                                 array(0, 0),
@@ -353,15 +407,16 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                                 array(1, 1)
                             )
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiPolygonValueWithSrid' => array(
                 'value'    => 'SRID=4326;MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),((1 1, 3 1, 3 3, 1 3, 1 1)))',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'MULTIPOLYGON',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'MULTIPOLYGON',
+                    'value'     => array(
                         array(
                             array(
                                 array(0, 0),
@@ -387,7 +442,8 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                                 array(1, 1)
                             )
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingMultiPolygonValueMissingParenthesis' => array(
@@ -397,49 +453,51 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingGeometryCollectionValue' => array(
                 'value'    => 'GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',
                 'expected' => array(
-                    'srid'  => null,
-                    'type'  => 'GEOMETRYCOLLECTION',
-                    'value' => array(
+                    'srid'      => null,
+                    'type'      => 'GEOMETRYCOLLECTION',
+                    'value'     => array(
                         array(
-                            'type'  => 'POINT',
-                            'value' => array(10, 10)
+                            'type'      => 'POINT',
+                            'value'     => array(10, 10)
                         ),
                         array(
-                            'type'  => 'POINT',
-                            'value' => array(30, 30)
+                            'type'      => 'POINT',
+                            'value'     => array(30, 30)
                         ),
                         array(
-                            'type'  => 'LINESTRING',
-                            'value' => array(
+                            'type'      => 'LINESTRING',
+                            'value'     => array(
                                 array(15, 15),
                                 array(20, 20)
                             )
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingGeometryCollectionValueWithSrid' => array(
                 'value'    => 'SRID=4326;GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',
                 'expected' => array(
-                    'srid'  => 4326,
-                    'type'  => 'GEOMETRYCOLLECTION',
-                    'value' => array(
+                    'srid'      => 4326,
+                    'type'      => 'GEOMETRYCOLLECTION',
+                    'value'     => array(
                         array(
-                            'type'  => 'POINT',
-                            'value' => array(10, 10)
+                            'type'      => 'POINT',
+                            'value'     => array(10, 10)
                         ),
                         array(
-                            'type'  => 'POINT',
-                            'value' => array(30, 30)
+                            'type'      => 'POINT',
+                            'value'     => array(30, 30)
                         ),
                         array(
-                            'type'  => 'LINESTRING',
-                            'value' => array(
+                            'type'      => 'LINESTRING',
+                            'value'     => array(
                                 array(15, 15),
                                 array(20, 20)
                             )
                         )
-                    )
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingGeometryCollectionValueWithBadType' => array(

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -149,6 +149,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'dimension' => null
                 )
             ),
+            'testParsingPointZValueWithSrid' => array(
+                'value'    => 'SRID=4326;POINT(34.23 -87 10)',
+                'expected' => array(
+                    'srid'      => 4326,
+                    'type'      => 'POINT',
+                    'value'     => array(34.23, -87, 10),
+                    'dimension' => 'Z'
+                )
+            ),
             'testParsingPointValueScientificWithSrid' => array(
                 'value'    => 'SRID=4326;POINT(4.23e-005 -8E-003)',
                 'expected' => array(
@@ -165,6 +174,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingPointValueMissingCoordinate' => array(
                 'value'    => 'POINT(34.23)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 11: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "POINT(34.23)"')
+            ),
+            'testParsingPointMValueMissingCoordinate' => array(
+                'value'    => 'POINTM(34.23 10)',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 15: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "POINTM(34.23 10)"')
+            ),
+            'testParsingPointMValueExtraCoordinate' => array(
+                'value'    => 'POINTM(34.23 10 30 40)',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 19: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "40" in value "POINTM(34.23 10 30 40)"')
+            ),
+            'testParsingPointZMValueMissingCoordinate' => array(
+                'value'    => 'POINTZM(34.23 10 45)',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 19: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "POINTZM(34.23 10 45)"')
+            ),
+            'testParsingPointZMValueExtraCoordinate' => array(
+                'value'    => 'POINTZM(34.23 10 45 4.5 99)',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 24: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "99" in value "POINTZM(34.23 10 45 4.5 99)"')
             ),
             'testParsingPointValueShortString' => array(
                 'value'    => 'POINT(34.23',
@@ -190,6 +215,42 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'dimension' => null
                 )
             ),
+            'testParsingLineStringZValue' => array(
+                'value'    => 'LINESTRING(34.23 -87 10, 45.3 -92 10)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(
+                        array(34.23, -87, 10),
+                        array(45.3, -92, 10)
+                    ),
+                    'dimension' => 'Z'
+                )
+            ),
+            'testParsingLineStringMValue' => array(
+                'value'    => 'LINESTRINGM(34.23 -87 10, 45.3 -92 10)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(
+                        array(34.23, -87, 10),
+                        array(45.3, -92, 10)
+                    ),
+                    'dimension' => 'M'
+                )
+            ),
+            'testParsingLineStringZMValue' => array(
+                'value'    => 'LINESTRINGZM(34.23 -87 10 20, 45.3 -92 10 20)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(
+                        array(34.23, -87, 10, 20),
+                        array(45.3, -92, 10, 20)
+                    ),
+                    'dimension' => 'ZM'
+                )
+            ),
             'testParsingLineStringValueWithSrid' => array(
                 'value'    => 'SRID=4326;LINESTRING(34.23 -87, 45.3 -92)',
                 'expected' => array(
@@ -206,6 +267,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'value'    => 'LINESTRING(34.23 -87, 45.3)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 26: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got ")" in value "LINESTRING(34.23 -87, 45.3)"')
             ),
+            'testParsingLineStringValueMismatchedDimensions' => array(
+                'value'    => 'LINESTRING(34.23 -87, 45.3 56 23.4)',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 30: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "23.4" in value "LINESTRING(34.23 -87, 45.3 56 23.4)"')
+            ),
             'testParsingPolygonValue' => array(
                 'value'    => 'POLYGON((0 0,10 0,10 10,0 10,0 0))',
                 'expected' => array(
@@ -221,6 +286,57 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         )
                     ) ,
                     'dimension' => null
+                )
+            ),
+            'testParsingPolygonZValue' => array(
+                'value'    => 'POLYGON((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0))',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
+                        array(
+                            array(0, 0, 0),
+                            array(10, 0, 0),
+                            array(10, 10, 0),
+                            array(0, 10, 0),
+                            array(0, 0, 0)
+                        )
+                    ) ,
+                    'dimension' => 'Z'
+                )
+            ),
+            'testParsingPolygonMValue' => array(
+                'value'    => 'POLYGONM((0 0 0,10 0 0,10 10 0,0 10 0,0 0 0))',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
+                        array(
+                            array(0, 0, 0),
+                            array(10, 0, 0),
+                            array(10, 10, 0),
+                            array(0, 10, 0),
+                            array(0, 0, 0)
+                        )
+                    ) ,
+                    'dimension' => 'M'
+                )
+            ),
+            'testParsingPolygonZMValue' => array(
+                'value'    => 'POLYGONZM((0 0 0 1,10 0 0 1,10 10 0 1,0 10 0 1,0 0 0 1))',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(
+                        array(
+                            array(0, 0, 0, 1),
+                            array(10, 0, 0, 1),
+                            array(10, 10, 0, 1),
+                            array(0, 10, 0, 1),
+                            array(0, 0, 0, 1)
+                        )
+                    ) ,
+                    'dimension' => 'ZM'
                 )
             ),
             'testParsingPolygonValueWithSrid' => array(
@@ -292,6 +408,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'value'    => 'POLYGON(0 0,10 0,10 10,0 10,0 0)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\WKT\Lexer::T_OPEN_PARENTHESIS, got "0" in value "POLYGON(0 0,10 0,10 10,0 10,0 0)"')
             ),
+            'testParsingPolygonValueMismatchedDimension' => array(
+                'value'    => 'POLYGON((0 0,10 0,10 10 10,0 10,0 0))',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 24: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "10" in value "POLYGON((0 0,10 0,10 10 10,0 10,0 0))"')
+            ),
             'testParsingPolygonValueMultiRingMissingComma' => array(
                 'value'    => 'POLYGON((0 0,10 0,10 10,0 10,0 0)(5 5,7 5,7 7,5 7,5 5))',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 33: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "(" in value "POLYGON((0 0,10 0,10 10,0 10,0 0)(5 5,7 5,7 7,5 7,5 5))"')
@@ -308,6 +428,20 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         array(0, 10)
                     ),
                     'dimension' => null
+                )
+            ),
+            'testParsingMultiPointMValue' => array(
+                'value'    => 'MULTIPOINTM(0 0 0,10 0 0,10 10 0,0 10 0)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'MULTIPOINT',
+                    'value'     => array(
+                        array(0, 0, 0),
+                        array(10, 0, 0),
+                        array(10, 10, 0),
+                        array(0, 10, 0)
+                    ),
+                    'dimension' => 'M'
                 )
             ),
             'testParsingMultiPointValueWithSrid' => array(
@@ -348,6 +482,28 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         )
                     ),
                     'dimension' => null
+                )
+            ),
+            'testParsingMultiLineStringZValue' => array(
+                'value'    => 'MULTILINESTRING((0 0 0,10 0 0,10 10 0,0 10 0),(5 5 1,7 5 1,7 7 1,5 7 1))',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'MULTILINESTRING',
+                    'value'     => array(
+                        array(
+                            array(0, 0, 0),
+                            array(10, 0, 0),
+                            array(10, 10, 0),
+                            array(0, 10, 0),
+                        ),
+                        array(
+                            array(5, 5, 1),
+                            array(7, 5, 1),
+                            array(7, 7, 1),
+                            array(5, 7, 1),
+                        )
+                    ),
+                    'dimension' => 'Z'
                 )
             ),
             'testParsingMultiLineStringValueWithSrid' => array(
@@ -475,6 +631,31 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'dimension' => null
                 )
             ),
+            'testParsingGeometryCollectionMValue' => array(
+                'value'    => 'GEOMETRYCOLLECTIONM(POINT(10 10 0), POINT(30 30 0), LINESTRING(15 15 0, 20 20 0))',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'GEOMETRYCOLLECTION',
+                    'value'     => array(
+                        array(
+                            'type'      => 'POINT',
+                            'value'     => array(10, 10, 0)
+                        ),
+                        array(
+                            'type'      => 'POINT',
+                            'value'     => array(30, 30, 0)
+                        ),
+                        array(
+                            'type'      => 'LINESTRING',
+                            'value'     => array(
+                                array(15, 15, 0),
+                                array(20, 20, 0)
+                            )
+                        )
+                    ),
+                    'dimension' => 'M'
+                )
+            ),
             'testParsingGeometryCollectionValueWithSrid' => array(
                 'value'    => 'SRID=4326;GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',
                 'expected' => array(
@@ -503,6 +684,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingGeometryCollectionValueWithBadType' => array(
                 'value'    => 'GEOMETRYCOLLECTION(PNT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 19: Error: Expected CrEOF\Geo\WKT\Lexer::T_TYPE, got "PNT" in value "GEOMETRYCOLLECTION(PNT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))"')
+            ),
+            'testParsingGeometryCollectionValueWithMismatchedDimenstion' => array(
+                'value'    => 'GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30 10), LINESTRING(15 15, 20 20))',
+                'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 45: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "10" in value "GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30 10), LINESTRING(15 15, 20 20))"')
             )
         );
     }

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -1,9 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-
-error_reporting(E_ALL | E_STRICT);
-
-$loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CrEOF\Geo\WKT\Tests', __DIR__);
-$loader->register();


### PR DESCRIPTION
## [2.2.0] - 2016-05-03
### Added
- Tests namespace to PSR-0 autoload in composer.json.
- Support for 3DZ, 3DM, 4DZM objects added. Dimension(s) now in 'dimension' key of returned array.
### Changed
- Token pattern regex changed to capture numbers in scientific notation as a single value.
- Let PHP handle scientific number conversion to float instead of manually calculating.
- Only instantiate Lexer object in Parser constructor if it doesn't exist.
- Move function return value tests from switch statement in Lexer. Switch statement now doing only string comparison.
- Remove static visibility from Lexer instance in Parser.
- PHPUnit now bootstraps Composer autoload.
- Update PHPUnit config XML to be compliant with XSD.
- Documentation updated for 3DZ, 3DM, 4DZM support.
### Removed
- Removed E token used with scientific notation from Lexer.
- Removed now unused TestInit.
