### PR TITLE
Add support for empty objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Token to Lexer for EMPTY keyword.
+- Tests for EMPTY geometry.
 
 ### Changed
+- Empty array returned for TOKEN token.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,20 @@ If many values need to be parsed, a single ```Parser``` instance can be used:
 ```php
 $input1 = 'POLYGON((0 0,10 0,10 10,0 10,0 0))';
 $input2 = 'POINT(0,0)';
+$input3 = 'POINT EMPTY';
 
 $parser = new Parser();
 
 $value1 = $parser->parse($input1);
 $value2 = $parser->parse($input2);
+$value3 = $parser->parse($input3);
 ```
 
 ## Return
 
 The parser will return an array with the keys ```type```, ```value```, ```srid```, and ```dimension```.
 - ```type``` string, the spatial object type (POINT, LINESTRING, etc.) without any dimension.
-- ```value``` array, contains integer or float values for points, or nested arrays containing these based on spatial object type.
+- ```value``` array, contains integer or float values for points, nested arrays containing these based on spatial object type, or empty array for EMPTY geometry.
 - ```srid``` integer, the SRID if EWKT value was parsed, ```null``` otherwise.
 - ```dimension``` string, will contain ```Z```, ```M```, or ```ZM``` for the respective 3D and 4D objects, ```null``` otherwise.
 

--- a/lib/CrEOF/Geo/WKT/Lexer.php
+++ b/lib/CrEOF/Geo/WKT/Lexer.php
@@ -44,6 +44,7 @@ class Lexer extends AbstractLexer
     const T_EQUALS             = 11;
     const T_MINUS              = 14;
     const T_SEMICOLON          = 50;
+    const T_EMPTY              = 60;
     const T_SRID               = 500;
     const T_ZM                 = 501;
     const T_Z                  = 502;

--- a/lib/CrEOF/Geo/WKT/Parser.php
+++ b/lib/CrEOF/Geo/WKT/Parser.php
@@ -144,6 +144,25 @@ class Parser
             $this->dimension = $this->lexer->value();
         }
 
+        if (! $this->lexer->isNextToken(Lexer::T_EMPTY)) {
+            return $this->value($type);
+        }
+
+        $this->match(Lexer::T_EMPTY);
+
+        return array(
+            'type'  => $type,
+            'value' => array()
+        );
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return array
+     */
+    protected function value($type)
+    {
         $this->match(Lexer::T_OPEN_PARENTHESIS);
 
         $value = $this->$type();
@@ -155,7 +174,6 @@ class Parser
             'value' => $value
         );
     }
-
     /**
      * Match a coordinate pair
      *

--- a/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/LexerTest.php
@@ -79,10 +79,23 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     public function tokenData()
     {
         return array(
+            'EMPTY' => array(
+                'value'    => 'EMPTY',
+                'expected' => array(
+                    array(Lexer::T_EMPTY, 'EMPTY', 0)
+                )
+            ),
             'POINT' => array(
                 'value'    => 'POINT',
                 'expected' => array(
                     array(Lexer::T_POINT, 'POINT', 0)
+                )
+            ),
+            'POINT EMPTY' => array(
+                'value'    => 'POINT EMPTY',
+                'expected' => array(
+                    array(Lexer::T_POINT, 'POINT', 0),
+                    array(Lexer::T_EMPTY, 'EMPTY', 6)
                 )
             ),
             'POINTM' => array(

--- a/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKT/Tests/ParserTest.php
@@ -86,6 +86,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'value'    => 'PNT(10 10)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 0: Error: Expected CrEOF\Geo\WKT\Lexer::T_TYPE, got "PNT" in value "PNT(10 10)"')
             ),
+            'testParsingEmptyPointValue' => array(
+                'value'    => 'POINT EMPTY',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POINT',
+                    'value'     => array(),
+                    'dimension' => null
+                )
+            ),
             'testParsingPointValue' => array(
                 'value'    => 'POINT(34.23 -87)',
                 'expected' => array(
@@ -203,6 +212,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'value'    => 'POINT(10, 10)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\WKT\Lexer::T_INTEGER, got "," in value "POINT(10, 10)"')
             ),
+            'testParsingEmptyLineStringValue' => array(
+                'value'    => 'LINESTRING EMPTY',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'LINESTRING',
+                    'value'     => array(),
+                    'dimension' => null
+                )
+            ),
             'testParsingLineStringValue' => array(
                 'value'    => 'LINESTRING(34.23 -87, 45.3 -92)',
                 'expected' => array(
@@ -271,6 +289,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'value'    => 'LINESTRING(34.23 -87, 45.3 56 23.4)',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 30: Error: Expected CrEOF\Geo\WKT\Lexer::T_CLOSE_PARENTHESIS, got "23.4" in value "LINESTRING(34.23 -87, 45.3 56 23.4)"')
             ),
+            'testParsingEmptyPolygonValue' => array(
+                'value'    => 'POLYGON EMPTY',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'POLYGON',
+                    'value'     => array(),
+                    'dimension' => null
+                )
+            ),
             'testParsingPolygonValue' => array(
                 'value'    => 'POLYGON((0 0,10 0,10 10,0 10,0 0))',
                 'expected' => array(
@@ -284,7 +311,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10),
                             array(0, 0)
                         )
-                    ) ,
+                    ),
                     'dimension' => null
                 )
             ),
@@ -301,7 +328,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10, 0),
                             array(0, 0, 0)
                         )
-                    ) ,
+                    ),
                     'dimension' => 'Z'
                 )
             ),
@@ -318,7 +345,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10, 0),
                             array(0, 0, 0)
                         )
-                    ) ,
+                    ),
                     'dimension' => 'M'
                 )
             ),
@@ -335,7 +362,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                             array(0, 10, 0, 1),
                             array(0, 0, 0, 1)
                         )
-                    ) ,
+                    ),
                     'dimension' => 'ZM'
                 )
             ),
@@ -605,6 +632,29 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingMultiPolygonValueMissingParenthesis' => array(
                 'value'    => 'MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),(1 1, 3 1, 3 3, 1 3, 1 1))',
                 'expected' => new UnexpectedValueException('[Syntax Error] line 0, col 64: Error: Expected CrEOF\Geo\WKT\Lexer::T_OPEN_PARENTHESIS, got "1" in value "MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7,5 5)),(1 1, 3 1, 3 3, 1 3, 1 1))"')
+            ),
+            'testParsingEmptyGeometryCollectionValue' => array(
+                'value'    => 'GEOMETRYCOLLECTION EMPTY',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'GEOMETRYCOLLECTION',
+                    'value'     => array(),
+                    'dimension' => null
+                )
+            ),
+            'testParsingGeometryCollectionValueWithEmptyObject' => array(
+                'value'    => 'GEOMETRYCOLLECTION(POINT EMPTY)',
+                'expected' => array(
+                    'srid'      => null,
+                    'type'      => 'GEOMETRYCOLLECTION',
+                    'value'     => array(
+                        array(
+                            'type'      => 'POINT',
+                            'value'     => array()
+                        )
+                    ),
+                    'dimension' => null
+                )
             ),
             'testParsingGeometryCollectionValue' => array(
                 'value'    => 'GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))',


### PR DESCRIPTION
- Add support for empty objects `POINT EMPTY`, `LINESTRING EMPTY`, etc.  `value` index in returned array contains empty `array()`.
